### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
 setting.py
+# Created by https://www.gitignore.io/api/django
+
+### Django ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
+
+# End of https://www.gitignore.io/api/django


### PR DESCRIPTION
#Descripción
Qué ha cambiado?
Agregamos al gitignore soporte para Django.
- [ ] Frontend
- [ ] Backend
- [ X] Configuración del Server.

#Como puedo probar los cambios?
Por ejemplo los archivos y la carpeta node_modules ya no se suben al repo.  ver el archivo .gitignore.